### PR TITLE
Guarantee Transaction.toString() order

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,8 +8,7 @@ class Transaction {
     }
 
     toString() {
-        const json = [ this.item, this.payer, this.payee ];
-        return JSON.stringify(json);
+        return JSON.stringify([ this.item, this.payer, this.payee ]);
     }
 }
 

--- a/app.js
+++ b/app.js
@@ -8,7 +8,8 @@ class Transaction {
     }
 
     toString() {
-        return JSON.stringify(this);
+        const json = [ this.item, this.payer, this.payee ];
+        return JSON.stringify(json);
     }
 }
 


### PR DESCRIPTION
JSON.stringify() doesn't guarantee order, so passing in an array will ensure elements are always prepared in the same fashion.